### PR TITLE
Add license compliance with reuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,17 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: userfeedbackapi
+Source: https://github.com/diggsweden/userfeedbackapi
+
+Files: docs/**.svg docs/**.json docs/**.drawio docs/**.png
+Copyright: Digg - Agency for Digital Government 
+License: CC0-1.0
+
+# Third-party files.
+
+Files: gradlew*
+Copyright: The original author or authors <info@gradle.com>
+License: Apache-2.0
+
+Files: gradle/** */
+Copyright: The original author or authors <info@gradle.com>
+License: Apache-2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 FROM amazoncorretto:17-alpine3.16
 ARG JAR_FILE=build/libs/UserRatingAPI-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 FROM amazoncorretto:17-alpine3.16
 ARG JAR_FILE=build/libs/UserRatingAPI-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 FROM amazoncorretto:17-alpine3.16
 ARG JAR_FILE=build/libs/UserRatingAPI-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: CC0-1.0
 
 # UserFeedbackAPI
 
-[![License: MIT](https://img.shields.io/badge/Licence-MIT-yellow)](https://img.shields.io/badge/Licence-MIT-yellow) [![Standard commitment](https://img.shields.io/badge/Standard_for_public_code-commitment-green)](https://img.shields.io/badge/Standard_for_public_code-commitment-green)
+[![License: MIT](https://img.shields.io/badge/Licence-MIT-yellow)](https://img.shields.io/badge/Licence-MIT-yellow) 
 
 [![API Documentation](https://img.shields.io/badge/API_documentation-OAS3-red)](https://img.shields.io/badge/API_documentation-OAS3-red)
 
@@ -21,6 +21,8 @@ SPDX-License-Identifier: CC0-1.0
 [![Databas](https://img.shields.io/badge/Databas-PostgreSQL-blue)](https://img.shields.io/badge/Databas-PostgreSQL-blue) [![Cache](https://img.shields.io/badge/Cache-Redis-blue)](https://img.shields.io/badge/Cache-Redis-blue)
 
 [![Authentication](https://img.shields.io/badge/Authentication-Keycloak-orange)](https://img.shields.io/badge/Authentication-Keycloak-orange)
+
+[![REUSE status](https://api.reuse.software/badge/github.com/diggsweden/userfeedbackapi)](https://api.reuse.software/info/github.com/diggsweden/userfeedbackapi)
 
 <br />
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: CC0-1.0
+
 plugins {
     id 'org.springframework.boot' version '2.7.8'
     id 'java'

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 echo ########### Building jar file ###########
 gradle build
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip

--- a/k8/deployment.yaml
+++ b/k8/deployment.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8/keycloak-loadbalancer.yaml
+++ b/k8/keycloak-loadbalancer.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/k8/keycloak-server.yaml
+++ b/k8/keycloak-server.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8/keycloak-service.yaml
+++ b/k8/keycloak-service.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/k8/kubernetes-secrets.yaml
+++ b/k8/kubernetes-secrets.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/k8/kubernetes_cluster.yaml
+++ b/k8/kubernetes_cluster.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 

--- a/k8/loadbalancer.yaml
+++ b/k8/loadbalancer.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/k8/loadbalancer_no_cert.yaml
+++ b/k8/loadbalancer_no_cert.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/k8/redis-server.yaml
+++ b/k8/redis-server.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8/redis-service.yaml
+++ b/k8/redis-service.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/keycloak-compose.yml
+++ b/keycloak-compose.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 version: '3.9'
 
 services:

--- a/src/main/java/se/digg/api/UserFeedbackApiApplication.java
+++ b/src/main/java/se/digg/api/UserFeedbackApiApplication.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api;
 
 import org.slf4j.Logger;

--- a/src/main/java/se/digg/api/config/CorsConfig.java
+++ b/src/main/java/se/digg/api/config/CorsConfig.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.config;
 
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/se/digg/api/config/HostValidationConfig.java
+++ b/src/main/java/se/digg/api/config/HostValidationConfig.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.config;
 
 import lombok.Getter;

--- a/src/main/java/se/digg/api/config/ImpressionConfig.java
+++ b/src/main/java/se/digg/api/config/ImpressionConfig.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.config;
 
 import lombok.Getter;

--- a/src/main/java/se/digg/api/config/LocalSecurityConfig.java
+++ b/src/main/java/se/digg/api/config/LocalSecurityConfig.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.config;
 
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/se/digg/api/config/OAuth2SecurityConfig.java
+++ b/src/main/java/se/digg/api/config/OAuth2SecurityConfig.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.config;
 
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/se/digg/api/config/RatingConfig.java
+++ b/src/main/java/se/digg/api/config/RatingConfig.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.config;
 
 import lombok.Getter;

--- a/src/main/java/se/digg/api/config/RedisClusterConfig.java
+++ b/src/main/java/se/digg/api/config/RedisClusterConfig.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.config;
 
 import lombok.Getter;

--- a/src/main/java/se/digg/api/config/RedisConfig.java
+++ b/src/main/java/se/digg/api/config/RedisConfig.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.config;
 
 import lombok.Getter;

--- a/src/main/java/se/digg/api/config/RestTemplates.java
+++ b/src/main/java/se/digg/api/config/RestTemplates.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.config;
 
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/se/digg/api/config/SwaggerConfig.java
+++ b/src/main/java/se/digg/api/config/SwaggerConfig.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.config;
 
 import io.swagger.v3.oas.models.Components;

--- a/src/main/java/se/digg/api/controller/AdminController.java
+++ b/src/main/java/se/digg/api/controller/AdminController.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.controller;
 
 import com.google.gson.JsonObject;

--- a/src/main/java/se/digg/api/controller/BaseController.java
+++ b/src/main/java/se/digg/api/controller/BaseController.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.controller;
 
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/se/digg/api/controller/ImpressionController.java
+++ b/src/main/java/se/digg/api/controller/ImpressionController.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.controller;
 
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/se/digg/api/controller/OrganisationController.java
+++ b/src/main/java/se/digg/api/controller/OrganisationController.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.controller;
 
 import com.google.gson.JsonObject;

--- a/src/main/java/se/digg/api/controller/RatingController.java
+++ b/src/main/java/se/digg/api/controller/RatingController.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.controller;
 
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/se/digg/api/controller/RedisController.java
+++ b/src/main/java/se/digg/api/controller/RedisController.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.controller;
 
 import com.google.gson.JsonObject;

--- a/src/main/java/se/digg/api/dto/ApiKeyDTO.java
+++ b/src/main/java/se/digg/api/dto/ApiKeyDTO.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.dto;
 
 import com.google.gson.JsonObject;

--- a/src/main/java/se/digg/api/dto/ContextDTO.java
+++ b/src/main/java/se/digg/api/dto/ContextDTO.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.dto;
 
 import com.google.gson.JsonObject;

--- a/src/main/java/se/digg/api/dto/ContextMetaDTO.java
+++ b/src/main/java/se/digg/api/dto/ContextMetaDTO.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.dto;
 
 import com.google.gson.JsonObject;

--- a/src/main/java/se/digg/api/dto/DomainDTO.java
+++ b/src/main/java/se/digg/api/dto/DomainDTO.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.dto;
 
 import com.google.gson.JsonObject;

--- a/src/main/java/se/digg/api/dto/ImpressionDTO.java
+++ b/src/main/java/se/digg/api/dto/ImpressionDTO.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.dto;
 
 import com.google.gson.JsonObject;

--- a/src/main/java/se/digg/api/dto/OrganisationDTO.java
+++ b/src/main/java/se/digg/api/dto/OrganisationDTO.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.dto;
 
 import com.google.gson.JsonObject;

--- a/src/main/java/se/digg/api/dto/RatingDTO.java
+++ b/src/main/java/se/digg/api/dto/RatingDTO.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.dto;
 
 import com.google.gson.JsonObject;

--- a/src/main/java/se/digg/api/error/ApiError.java
+++ b/src/main/java/se/digg/api/error/ApiError.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.error;
 
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;

--- a/src/main/java/se/digg/api/error/ApiSubError.java
+++ b/src/main/java/se/digg/api/error/ApiSubError.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.error;
 
 public class ApiSubError {

--- a/src/main/java/se/digg/api/error/ApiValidationError.java
+++ b/src/main/java/se/digg/api/error/ApiValidationError.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.error;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/se/digg/api/exception/DomainValidationException.java
+++ b/src/main/java/se/digg/api/exception/DomainValidationException.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.exception;
 
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/se/digg/api/exception/EntityNotFoundException.java
+++ b/src/main/java/se/digg/api/exception/EntityNotFoundException.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.exception;
 
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/se/digg/api/exception/GeneralRuntimeException.java
+++ b/src/main/java/se/digg/api/exception/GeneralRuntimeException.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.exception;
 
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/se/digg/api/exception/LowerCaseClassNameResolver.java
+++ b/src/main/java/se/digg/api/exception/LowerCaseClassNameResolver.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.exception;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;

--- a/src/main/java/se/digg/api/exception/RestExceptionHandler.java
+++ b/src/main/java/se/digg/api/exception/RestExceptionHandler.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.exception;
 
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/se/digg/api/form/ImpressionForm.java
+++ b/src/main/java/se/digg/api/form/ImpressionForm.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.form;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/se/digg/api/form/RatingForm.java
+++ b/src/main/java/se/digg/api/form/RatingForm.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.form;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/se/digg/api/form/RedisForm.java
+++ b/src/main/java/se/digg/api/form/RedisForm.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.form;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/se/digg/api/form/RegisterForm.java
+++ b/src/main/java/se/digg/api/form/RegisterForm.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.form;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/se/digg/api/form/UnRegisterForm.java
+++ b/src/main/java/se/digg/api/form/UnRegisterForm.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.form;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/se/digg/api/logic/AdminLogic.java
+++ b/src/main/java/se/digg/api/logic/AdminLogic.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.logic;
 
 import org.springframework.stereotype.Component;

--- a/src/main/java/se/digg/api/logic/ImpressionLogic.java
+++ b/src/main/java/se/digg/api/logic/ImpressionLogic.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.logic;
 
 import org.javatuples.Pair;

--- a/src/main/java/se/digg/api/logic/OrganisationLogic.java
+++ b/src/main/java/se/digg/api/logic/OrganisationLogic.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.logic;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/se/digg/api/logic/RatingLogic.java
+++ b/src/main/java/se/digg/api/logic/RatingLogic.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.logic;
 
 import org.springframework.stereotype.Component;

--- a/src/main/java/se/digg/api/logic/RedisCacheLogic.java
+++ b/src/main/java/se/digg/api/logic/RedisCacheLogic.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.logic;
 
 import com.google.gson.Gson;

--- a/src/main/java/se/digg/api/model/ApiKey.java
+++ b/src/main/java/se/digg/api/model/ApiKey.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.model;
 
 import lombok.Getter;

--- a/src/main/java/se/digg/api/model/Context.java
+++ b/src/main/java/se/digg/api/model/Context.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.model;
 
 import lombok.Getter;

--- a/src/main/java/se/digg/api/model/ContextImpressionRatingLookup.java
+++ b/src/main/java/se/digg/api/model/ContextImpressionRatingLookup.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.model;
 
 import lombok.Getter;

--- a/src/main/java/se/digg/api/model/ContextMeta.java
+++ b/src/main/java/se/digg/api/model/ContextMeta.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.model;
 
 import lombok.Getter;

--- a/src/main/java/se/digg/api/model/Domain.java
+++ b/src/main/java/se/digg/api/model/Domain.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.model;
 
 import lombok.Getter;

--- a/src/main/java/se/digg/api/model/Impression.java
+++ b/src/main/java/se/digg/api/model/Impression.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.model;
 
 import lombok.Getter;

--- a/src/main/java/se/digg/api/model/Organisation.java
+++ b/src/main/java/se/digg/api/model/Organisation.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.model;
 
 import lombok.Getter;

--- a/src/main/java/se/digg/api/model/Rating.java
+++ b/src/main/java/se/digg/api/model/Rating.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.model;
 
 import lombok.Getter;

--- a/src/main/java/se/digg/api/repository/ApiKeyRepository.java
+++ b/src/main/java/se/digg/api/repository/ApiKeyRepository.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.repository;
 
 import org.springframework.data.repository.CrudRepository;

--- a/src/main/java/se/digg/api/repository/ContextMetaRepository.java
+++ b/src/main/java/se/digg/api/repository/ContextMetaRepository.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.repository;
 
 import org.springframework.data.repository.CrudRepository;

--- a/src/main/java/se/digg/api/repository/ContextRepository.java
+++ b/src/main/java/se/digg/api/repository/ContextRepository.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.repository;
 
 import org.springframework.data.repository.CrudRepository;

--- a/src/main/java/se/digg/api/repository/DomainRepository.java
+++ b/src/main/java/se/digg/api/repository/DomainRepository.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.repository;
 
 import org.springframework.data.repository.CrudRepository;

--- a/src/main/java/se/digg/api/repository/ImpressionRepository.java
+++ b/src/main/java/se/digg/api/repository/ImpressionRepository.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.repository;
 
 import org.springframework.data.repository.CrudRepository;

--- a/src/main/java/se/digg/api/repository/OrganisationRepository.java
+++ b/src/main/java/se/digg/api/repository/OrganisationRepository.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.repository;
 
 import org.springframework.data.repository.CrudRepository;

--- a/src/main/java/se/digg/api/repository/RatingRepository.java
+++ b/src/main/java/se/digg/api/repository/RatingRepository.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.repository;
 
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/se/digg/api/response/BadRequestResponse.java
+++ b/src/main/java/se/digg/api/response/BadRequestResponse.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/se/digg/api/response/ConflictResponse.java
+++ b/src/main/java/se/digg/api/response/ConflictResponse.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/se/digg/api/response/CustomResponse.java
+++ b/src/main/java/se/digg/api/response/CustomResponse.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.response;
 
 import com.google.gson.JsonObject;

--- a/src/main/java/se/digg/api/response/ForbiddenResponse.java
+++ b/src/main/java/se/digg/api/response/ForbiddenResponse.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/se/digg/api/service/ApiKeyService.java
+++ b/src/main/java/se/digg/api/service/ApiKeyService.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.service;
 
 import se.digg.api.dto.ApiKeyDTO;

--- a/src/main/java/se/digg/api/service/ApiKeyServiceImpl.java
+++ b/src/main/java/se/digg/api/service/ApiKeyServiceImpl.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.service;
 
 import org.springframework.stereotype.Service;

--- a/src/main/java/se/digg/api/service/ContextMetaService.java
+++ b/src/main/java/se/digg/api/service/ContextMetaService.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.service;
 
 import se.digg.api.dto.ContextMetaDTO;

--- a/src/main/java/se/digg/api/service/ContextMetaServiceImpl.java
+++ b/src/main/java/se/digg/api/service/ContextMetaServiceImpl.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.service;
 
 import org.springframework.stereotype.Service;

--- a/src/main/java/se/digg/api/service/ContextService.java
+++ b/src/main/java/se/digg/api/service/ContextService.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.service;
 
 import se.digg.api.dto.ContextDTO;

--- a/src/main/java/se/digg/api/service/ContextServiceImpl.java
+++ b/src/main/java/se/digg/api/service/ContextServiceImpl.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.service;
 
 import org.springframework.stereotype.Service;

--- a/src/main/java/se/digg/api/service/DomainService.java
+++ b/src/main/java/se/digg/api/service/DomainService.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.service;
 
 import se.digg.api.dto.DomainDTO;

--- a/src/main/java/se/digg/api/service/DomainServiceImpl.java
+++ b/src/main/java/se/digg/api/service/DomainServiceImpl.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.service;
 
 import org.springframework.stereotype.Service;

--- a/src/main/java/se/digg/api/service/ImpressionService.java
+++ b/src/main/java/se/digg/api/service/ImpressionService.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.service;
 
 import se.digg.api.dto.ImpressionDTO;

--- a/src/main/java/se/digg/api/service/ImpressionServiceImpl.java
+++ b/src/main/java/se/digg/api/service/ImpressionServiceImpl.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.service;
 
 import org.springframework.stereotype.Service;

--- a/src/main/java/se/digg/api/service/OrganisationService.java
+++ b/src/main/java/se/digg/api/service/OrganisationService.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.service;
 
 import se.digg.api.dto.OrganisationDTO;

--- a/src/main/java/se/digg/api/service/OrganisationServiceImpl.java
+++ b/src/main/java/se/digg/api/service/OrganisationServiceImpl.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.service;
 
 

--- a/src/main/java/se/digg/api/service/RatingService.java
+++ b/src/main/java/se/digg/api/service/RatingService.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.service;
 
 import org.javatuples.Pair;

--- a/src/main/java/se/digg/api/service/RatingServiceImpl.java
+++ b/src/main/java/se/digg/api/service/RatingServiceImpl.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.service;
 
 import org.javatuples.Pair;

--- a/src/main/java/se/digg/api/service/RedisCacheService.java
+++ b/src/main/java/se/digg/api/service/RedisCacheService.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.service;
 
 public interface RedisCacheService {

--- a/src/main/java/se/digg/api/service/RedisCacheServiceImpl.java
+++ b/src/main/java/se/digg/api/service/RedisCacheServiceImpl.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.service;
 
 import com.google.gson.Gson;

--- a/src/main/java/se/digg/api/utils/DateFormats.java
+++ b/src/main/java/se/digg/api/utils/DateFormats.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.utils;
 
 import java.text.SimpleDateFormat;

--- a/src/main/java/se/digg/api/utils/KeycloakLogoutHandler.java
+++ b/src/main/java/se/digg/api/utils/KeycloakLogoutHandler.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.utils;
 
 import org.slf4j.Logger;

--- a/src/main/java/se/digg/api/utils/WebUtils.java
+++ b/src/main/java/se/digg/api/utils/WebUtils.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.utils;
 
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
+
 #
 # JPA
 spring.datasource.url=jdbc:postgresql://[ INSERT_DB_URL e.g. name-rds-prod.cluster-ccccc11ccccc.eu-north-1.rds.amazonaws.com ]:5432/[ INSERT_DB_NAME ]?autoReconnect=true

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
 #
 # JPA
 spring.datasource.url=jdbc:postgresql://[ INSERT_DB_URL e.g. name-rds-prod.cluster-ccccc11ccccc.eu-north-1.rds.amazonaws.com ]:5432/[ INSERT_DB_NAME ]?autoReconnect=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
 #
 # Messages
 spring.application.msg.welcome=Welcome to the user feedback collection API's base controller!

--- a/src/main/resources/logback-console.xml
+++ b/src/main/resources/logback-console.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
 <configuration>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/src/main/resources/logback-rolling-file-and-console.xml
+++ b/src/main/resources/logback-rolling-file-and-console.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
 <configuration>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/src/main/resources/logback-rolling-file.xml
+++ b/src/main/resources/logback-rolling-file.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
 <configuration>
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <prudent>true</prudent>

--- a/src/main/resources/templates/error/error.html
+++ b/src/main/resources/templates/error/error.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>

--- a/src/test/java/se/digg/api/endtoend/ApplicationEndToEndTestSuite.java
+++ b/src/test/java/se/digg/api/endtoend/ApplicationEndToEndTestSuite.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.endtoend;
 
 import org.junit.platform.suite.api.SelectClasses;

--- a/src/test/java/se/digg/api/endtoend/ImpressionEndToEndTest.java
+++ b/src/test/java/se/digg/api/endtoend/ImpressionEndToEndTest.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.endtoend;
 
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;

--- a/src/test/java/se/digg/api/endtoend/RatingEndToEndTest.java
+++ b/src/test/java/se/digg/api/endtoend/RatingEndToEndTest.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.endtoend;
 
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;

--- a/src/test/java/se/digg/api/endtoend/RegisterOrganisationEndToEndTest.java
+++ b/src/test/java/se/digg/api/endtoend/RegisterOrganisationEndToEndTest.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: MIT
+
 package se.digg.api.endtoend;
 
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
 #
 # Messages
 spring.application.msg.welcome=Welcome to the user feedback collection API's base controller!

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
 <configuration>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>


### PR DESCRIPTION
This PR makes the project license compliance specification with reuse lint.
https://reuse.software/

Even though it is many affected files, the pr is scroll friendly and contains no logic.
It should be a quick general overview before merging it.

Basically, add adds license headers in spdx-format, as per the resuse-specification.
It also adds a missing reuse LICENSES file, apache 2.0, and the .reuse/dep5 which takes care of the licening for binary files etc.

Note: the reuse badge in the README will be green when the project is public

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
